### PR TITLE
 feat: ✨ refactor and simplify /reload 

### DIFF
--- a/src/commands/developer/reload.js
+++ b/src/commands/developer/reload.js
@@ -5,6 +5,7 @@ const { loadEvents } = require('../../structures/handlers/loadEvents');
 const { loadModals } = require('../../structures/handlers/loadModals');
 const { loadButtons } = require('../../structures/handlers/loadButtons');
 const { loadSelectMenus } = require('../../structures/handlers/loadSelectMenus');
+const { loadJobs } = require('../../structures/handlers/loadJobs');
 
 const Logger = require('../../structures/funcs/util/Logger');
 
@@ -15,12 +16,20 @@ module.exports = {
     .setName("reload")
     .setDescription("Reload available commands and events in the bot")
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
-    .addSubcommand((options) => options.setName("events").setDescription("Reload events"))
-    .addSubcommand((options) => options.setName("commands").setDescription("Reload commands"))
-    .addSubcommand((options) => options.setName("modals").setDescription("Reload modals"))
-    .addSubcommand((options) => options.setName("buttons").setDescription("Reload buttons"))
-    .addSubcommand((options) => options.setName("selectmenus").setDescription("Reload selectmenus"))
-    
+    .addStringOption((option) => 
+        option.setName("type")
+        .setDescription("The type of loader to re-invoke")
+        .setChoices(
+            { name: "💥 All", value: "all" },
+            { name: "✨ Events", value: "events" },
+            { name: "🤖 Slash Commands", value: "commands" },
+            { name: "📝 Modals", value: "modals" },
+            { name: "🔘 Buttons", value: "buttons" },
+            { name: "📃 Select Menus", value: "selectmenus" },
+            { name: "🔧 Jobs", value: "jobs" }
+        )
+        .setRequired(true)
+    )
     .setContexts(InteractionContextType.Guild, InteractionContextType.BotDM),
 
     developer: true,
@@ -33,12 +42,23 @@ module.exports = {
      * @returns 
      */
     async execute(interaction, client) {
+        const type = interaction.options.getString("type");
         let embed = new EmbedBuilder()
         .setTitle(`🔃 Reloaded!`)
-        .setDescription(`Requested reload for all **${interaction.options.getSubcommand()}**!`)
-        .setColor(client.config.color);
+        .setDescription(`Successfully reloaded for ${type === 'all' ? '' : 'all '}**${type}**!`)
+        .setColor(client.config.color ?? 'DarkButNotBlack');
 
-        switch(interaction.options.getSubcommand()) {
+        switch(type) {
+            case "all": {
+                await loadEvents(client);
+                await loadCommands(client);
+                await loadModals(client);
+                await loadButtons(client);
+                await loadSelectMenus(client);
+                await loadJobs(client);
+                break;
+            };
+
             case "events": loadEvents(client);
             break;
             
@@ -53,9 +73,12 @@ module.exports = {
 
             case "selectmenus": await loadSelectMenus(client);
             break;
+
+            case "jobs": await loadJobs(client);
+            break;
         }
 
         await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
-        return Logger.warn(`[Reload] @${interaction.user.username} reloaded all ${interaction.options.getSubcommand()}`);
+        return Logger.warn(`[Reload] @${interaction.user.username} triggered a reload for all ${type}.`);
     }
 };

--- a/src/commands/developer/reload.js
+++ b/src/commands/developer/reload.js
@@ -45,7 +45,7 @@ module.exports = {
         const type = interaction.options.getString("type");
         let embed = new EmbedBuilder()
         .setTitle(`🔃 Reloaded!`)
-        .setDescription(`Successfully reloaded for ${type === 'all' ? '' : 'all '}**${type}**!`)
+        .setDescription(`Successfully reloaded ${type === 'all' ? '' : 'all '}**${type}**!`)
         .setColor(client.config.color ?? 'DarkButNotBlack');
 
         switch(type) {
@@ -79,6 +79,6 @@ module.exports = {
         }
 
         await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
-        return Logger.warn(`[Reload] @${interaction.user.username} triggered a reload for all ${type}.`);
+        return Logger.warn(`[Reload] @${interaction.user.username} triggered a reload for ${type === 'all' ? `` : `all `}${type}.`);
     }
 };

--- a/src/structures/handlers/loadJobs.js
+++ b/src/structures/handlers/loadJobs.js
@@ -11,7 +11,9 @@ const { loadFiles } = require('../funcs/fileLoader');
  * @param {ExtendedClient} client 
  */
 async function loadJobs(client) {
+    client.jobs.forEach(job => job.task.stop());
     client.jobs.clear();
+
     let jobsArray = [];
 
     const files = await loadFiles("jobs");

--- a/src/structures/handlers/loadJobs.js
+++ b/src/structures/handlers/loadJobs.js
@@ -11,7 +11,13 @@ const { loadFiles } = require('../funcs/fileLoader');
  * @param {ExtendedClient} client 
  */
 async function loadJobs(client) {
-    client.jobs.forEach(job => job.task.stop());
+    client.jobs.forEach(job => {
+        try {
+            job.task?.stop();
+        } catch (error) {
+            Logger.error(`[Jobs] Failed to stop ${job.id}: ${error.message}`);
+        }
+    });
     client.jobs.clear();
 
     let jobsArray = [];


### PR DESCRIPTION
This pull request updates the developer `reload` command to support reloading additional resources and improves its flexibility by consolidating reload options into a single string selector. It also introduces support for reloading "jobs" and ensures that jobs are properly stopped and cleared before being reloaded.

**Enhancements to the reload command:**

* Changed the reload command interface to use a single `type` string option with choices (including a new "jobs" option and an "all" option) instead of multiple subcommands, making the command more flexible and user-friendly.
* Updated the reload command logic to handle the new `type` option, including support for reloading all resources at once and specifically reloading jobs. [[1]](diffhunk://#diff-4b04af9a2e71439fbc80f49cfba4236ebbe0a74000d3e32a75beb886b68419f3R45-L41) [[2]](diffhunk://#diff-4b04af9a2e71439fbc80f49cfba4236ebbe0a74000d3e32a75beb886b68419f3R76-R82)
* Improved the reload command's response and logging to reflect the new reload options and to clarify which resources were reloaded. [[1]](diffhunk://#diff-4b04af9a2e71439fbc80f49cfba4236ebbe0a74000d3e32a75beb886b68419f3R45-L41) [[2]](diffhunk://#diff-4b04af9a2e71439fbc80f49cfba4236ebbe0a74000d3e32a75beb886b68419f3R76-R82)

**Support for jobs:**

* Added import and invocation of `loadJobs` in the reload command, enabling dynamic reloading of job tasks. [[1]](diffhunk://#diff-4b04af9a2e71439fbc80f49cfba4236ebbe0a74000d3e32a75beb886b68419f3R8) [[2]](diffhunk://#diff-4b04af9a2e71439fbc80f49cfba4236ebbe0a74000d3e32a75beb886b68419f3R45-L41) [[3]](diffhunk://#diff-4b04af9a2e71439fbc80f49cfba4236ebbe0a74000d3e32a75beb886b68419f3R76-R82)
* Updated `loadJobs` to stop and clear existing jobs before reloading, ensuring no duplicate or lingering tasks.